### PR TITLE
Support for ellipseMode().

### DIFF
--- a/Snippets/ellipseMode.sublime-snippet
+++ b/Snippets/ellipseMode.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+	<content><![CDATA[ellipseMode(${1:CENTER})]]></content>
+	<description>ellipseMode</description>
+	<scope>source.pde</scope>
+	<tabTrigger>ellipseMode</tabTrigger>
+</snippet>


### PR DESCRIPTION
Hello Benedikt,

I am here at IAAC in Barcelona and Cristobal Castilla is doing an awesome job teaching us Processing. We are using your awesome plugin for Sublime and we just noticed that ellipseMode() was missing. Cris showed us how to do a snippet, I merely cleaned it up a little and added it to the plugin.

Thank you
Bert
