### PR TITLE
split Snippets for fill stroke and background

### DIFF
--- a/Snippets/background grey alpha.sublime-snippet
+++ b/Snippets/background grey alpha.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <content><![CDATA[background(${1:grey}, ${2:alpha});]]></content>
+    <description>background grey alpha</description>
+    <scope>source.pde</scope>
+    <tabTrigger>background</tabTrigger>
+</snippet>

--- a/Snippets/background grey.sublime-snippet
+++ b/Snippets/background grey.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <content><![CDATA[background(${1:grey});]]></content>
+    <description>background grey</description>
+    <scope>source.pde</scope>
+    <tabTrigger>background</tabTrigger>
+</snippet>

--- a/Snippets/background rgb.sublime-snippet
+++ b/Snippets/background rgb.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <content><![CDATA[background(${1:red}, ${2:green}, ${3:blue});]]></content>
+    <description>background rgb</description>
+    <scope>source.pde</scope>
+    <tabTrigger>background</tabTrigger>
+</snippet>

--- a/Snippets/background rgba.sublime-snippet
+++ b/Snippets/background rgba.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <content><![CDATA[background(${1:red}, ${2:green}, ${3:blue}, ${6:alpha});]]></content>
+    <description>background rgba</description>
+    <scope>source.pde</scope>
+    <tabTrigger>background</tabTrigger>
+</snippet>

--- a/Snippets/fill grey alpha.sublime-snippet
+++ b/Snippets/fill grey alpha.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <content><![CDATA[fill(${1:grey}, ${2:alpha});]]></content>
+    <description>fill grey alpha</description>
+    <scope>source.pde</scope>
+    <tabTrigger>fill</tabTrigger>
+</snippet>

--- a/Snippets/fill grey.sublime-snippet
+++ b/Snippets/fill grey.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <content><![CDATA[fill(${1:grey});]]></content>
+    <description>fill grey</description>
+    <scope>source.pde</scope>
+    <tabTrigger>fill</tabTrigger>
+</snippet>

--- a/Snippets/fill rgb.sublime-snippet
+++ b/Snippets/fill rgb.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <content><![CDATA[fill(${1:red}, ${2:green}, ${3:blue});]]></content>
+    <description>fill rgb</description>
+    <scope>source.pde</scope>
+    <tabTrigger>fill</tabTrigger>
+</snippet>

--- a/Snippets/fill rgba.sublime-snippet
+++ b/Snippets/fill rgba.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <content><![CDATA[fill(${1:red}, ${2:green}, ${3:blue}, ${6:alpha});]]></content>
+    <description>fill rgba</description>
+    <scope>source.pde</scope>
+    <tabTrigger>fill</tabTrigger>
+</snippet>

--- a/Snippets/stroke grey alpha.sublime-snippet
+++ b/Snippets/stroke grey alpha.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <content><![CDATA[stroke(${1:grey}, ${2:alpha});]]></content>
+    <description>stroke grey alpha</description>
+    <scope>source.pde</scope>
+    <tabTrigger>stroke</tabTrigger>
+</snippet>

--- a/Snippets/stroke grey.sublime-snippet
+++ b/Snippets/stroke grey.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <content><![CDATA[stroke(${1:grey});]]></content>
+    <description>stroke grey</description>
+    <scope>source.pde</scope>
+    <tabTrigger>stroke</tabTrigger>
+</snippet>

--- a/Snippets/stroke rgb.sublime-snippet
+++ b/Snippets/stroke rgb.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <content><![CDATA[stroke(${1:red}, ${2:green}, ${3:blue});]]></content>
+    <description>stroke rgb</description>
+    <scope>source.pde</scope>
+    <tabTrigger>stroke</tabTrigger>
+</snippet>

--- a/Snippets/stroke rgba.sublime-snippet
+++ b/Snippets/stroke rgba.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <content><![CDATA[stroke(${1:red}, ${2:green}, ${3:blue}, ${6:alpha});]]></content>
+    <description>stroke rgba</description>
+    <scope>source.pde</scope>
+    <tabTrigger>stroke</tabTrigger>
+</snippet>


### PR DESCRIPTION
let you choose different versions:
grey / grey alpha / rgb / rgb alpha = 1 / 2 / 3 / 4 arguments for colorMode(HSL) / HEX Color

Choosing the right snippet is faster than deleting unnecessary arguments
