### PR TITLE
Cleans up Linux instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Make sure to run `Tools -> Install "processing-java"` after you have installed t
 This bundle assumes that you chose to install processing-java for all users (recomended). If you choose/have to install processing-java only in your home directory, then you have to slightly change the build script, see comment in `Processing.sublime-build`.
 
 ###Linux
-You will need to set your PATH to where your processing application is located, e.g.:
+You will need to set your PATH to where your processing application is located, e.g.:  
 `export PATH=$PATH:/opt/processing/processing-2.0b4`
 
-You also need to create an alias for `processing-java` in `/bin/` instead of `/usr/bin/`, e.g.:
+You also need to create an alias for `processing-java` in `/bin/` instead of `/usr/bin/`, e.g.:  
 `sudo ln -s /opt/processing/processing-java /bin/processing-java`
 
 ###Windows


### PR DESCRIPTION
- small formatting tweaks
- fixes the folder name to use the same name as the previous step
- removes note about `/opt/` since the step before it already shows it in `opt`
