### PR TITLE
Updated build systems with variant to re-run sketch

### DIFF
--- a/Build Systems/Processing 3.sublime-build
+++ b/Build Systems/Processing 3.sublime-build
@@ -1,43 +1,52 @@
 {
-    "selector": "source.pde",
-    "cmd": ["processing-java", "--sketch=$file_path", "--run", "--force"],
-    "file_regex": "^(...*?):([0-9]*)",
-    "encoding": "ISO8859-1",
+  "selector": "source.pde",
+  "cmd": ["processing-java", "--sketch=$file_path", "--output=$file_path/build-tmp", "--run", "--force"],
+  "file_regex": "^(...*?):([0-9]*)",
+  "encoding": "ISO8859-1",
 
-    // if you choose to install processing-java just in your home dir then use for the cmd "~/processing-java" instead of "processing-java"
-    "variants": [
+  // If you choose to install processing-java just in your home dir then use for the cmd "~/processing-java" instead of "processing-java"
+  "variants": [
 
-      { "cmd": ["processing-java", "--sketch=$file_path", "--present", "--force"],
-        "name": "Run sketch fullscreen"
-      },
-      
-      { "cmd": ["processing-java", "--sketch=$file_path", "--output=$file_path/build-tmp", "--run", "--force"],
-        "name": "Build & run sketch"
-      },
-
-      { "cmd": ["processing-java", "--sketch=$file_path", "--output=$file_path/build-tmp", "--present", "--force"],
-        "name": "Build & run sketch fullscreen"
+    { 
+      "name": "Re-run" ,
+      "windows": {
+        // Close old sketch on build.
+        "shell_cmd": "wmic process where \"Caption Like '%java.exe%' AND CommandLine Like '%$file_base_name%'\" call terminate 1>nul && processing-java --sketch=\"$file_path\" --run --force"
       },
 
-    	{ "cmd": ["processing-java", "--sketch=$file_path", "--output=$file_path/application.linux32", "--export", "--platform=linux", "--bits=32", "--force"],
-      	"name": "Export sketch as a 32-bit linux application"
-    	},
-
-      { "cmd": ["processing-java", "--sketch=$file_path", "--output=$file_path/application.linux64", "--export", "--platform=linux", "--bits=64", "--force"],
-        "name": "Export sketch as a 64-bit linux application"
+      "osx": {
+        // Close old sketch on build
+        "shell_cmd": "pkill -f \"java.*$file_path\\$\"; processing-java --sketch=\"$file_path\" --run --force"
       },
 
-    	{ "cmd": ["processing-java", "--sketch=$file_path", "--output=$file_path/application.macosx", "--export", "--platform=macosx", "--force"],
-      	"name": "Export sketch as a macosx application"
-    	},
-
-    	{ "cmd": ["processing-java", "--sketch=$file_path", "--output=$file_path/application.windows32", "--export", "--platform=windows", "--bits=32", "--force"],
-      	"name": "Export sketch as a 32-bit windows application"
-    	},
-
-      { "cmd": ["processing-java", "--sketch=$file_path", "--output=$file_path/application.windows64", "--export", "--platform=windows", "--bits=64", "--force"],
-        "name": "Export sketch as a 64-bit windows application"
+      "linux": {
+        // Close old sketch on build
+        "shell_cmd": "pkill -f \"java.*$file_path\\$\"; processing-java --sketch=\"$file_path\" --run --force"
       }
+    },
 
-	]
+    { 
+      "name": "Run sketch fullscreen",
+      "cmd": ["processing-java", "--sketch=$file_path", "--present", "--force"],
+      
+      "windows": {
+        "shell_cmd": "processing-java --sketch=\"$file_path\" --present --force"
+      },
+
+      "osx": {
+        "shell_cmd": "processing-java --sketch=\"$file_path\" --present --force"
+      },
+
+      "linux": {
+        "shell_cmd": "processing-java --sketch=\"$file_path\" --present --force"
+      },
+    },
+
+    // Exporting to other platforms is unavailable from processing-java command line
+    // Bug filed https://github.com/processing/processing/issues/2760
+    { 
+      "name": "Export sketch as an application",
+      "cmd": ["processing-java", "--sketch=$file_path", "--output=$file_path/application", "--export", "--force"],
+    }
+  ]
 }

--- a/Build Systems/Processing.sublime-build
+++ b/Build Systems/Processing.sublime-build
@@ -1,35 +1,52 @@
 {
-    "selector": "source.pde",
-    "cmd": ["processing-java", "--sketch=$file_path", "--output=$file_path/build-tmp", "--run", "--force"],
-    "file_regex": "^(...*?):([0-9]*)",
-    "encoding": "ISO8859-1",
+  "selector": "source.pde",
+  "cmd": ["processing-java", "--sketch=$file_path", "--output=$file_path/build-tmp", "--run", "--force"],
+  "file_regex": "^(...*?):([0-9]*)",
+  "encoding": "ISO8859-1",
 
-    // if you choose to install processing-java just in your home dir then use for the cmd "~/processing-java" instead of "processing-java"
-    "variants": [
+  // If you choose to install processing-java just in your home dir then use for the cmd "~/processing-java" instead of "processing-java"
+  "variants": [
 
-      { "cmd": ["processing-java", "--sketch=$file_path", "--output=$file_path/build-tmp", "--present", "--force"],
-        "name": "Run sketch fullscreen"
+    { 
+      "name": "Re-run" ,
+      "windows": {
+        // Close old sketch on build.
+        "shell_cmd": "wmic process where \"Caption Like '%java.exe%' AND CommandLine Like '%$file_base_name%'\" call terminate 1>nul && processing-java --sketch=\"$file_path\" --output=%TEMP%\\p5-build-tmp --run --force"
       },
 
-    	{ "cmd": ["processing-java", "--sketch=$file_path", "--output=$file_path/application.linux32", "--export", "--platform=linux", "--bits=32", "--force"],
-      	"name": "Export sketch as a 32-bit linux application"
-    	},
-
-      { "cmd": ["processing-java", "--sketch=$file_path", "--output=$file_path/application.linux64", "--export", "--platform=linux", "--bits=64", "--force"],
-        "name": "Export sketch as a 64-bit linux application"
+      "osx": {
+        // Close old sketch on build
+        "shell_cmd": "pkill -f \"java.*$file_path\\$\"; processing-java --sketch=\"$file_path\" --output=/tmp/p5-build-tmp --run --force"
       },
 
-    	{ "cmd": ["processing-java", "--sketch=$file_path", "--output=$file_path/application.macosx", "--export", "--platform=macosx", "--force"],
-      	"name": "Export sketch as a macosx application"
-    	},
-
-    	{ "cmd": ["processing-java", "--sketch=$file_path", "--output=$file_path/application.windows32", "--export", "--platform=windows", "--bits=32", "--force"],
-      	"name": "Export sketch as a 32-bit windows application"
-    	},
-
-      { "cmd": ["processing-java", "--sketch=$file_path", "--output=$file_path/application.windows64", "--export", "--platform=windows", "--bits=64", "--force"],
-        "name": "Export sketch as a 64-bit windows application"
+      "linux": {
+        // Close old sketch on build
+        "shell_cmd": "pkill -f \"java.*$file_path\\$\"; processing-java --sketch=\"$file_path\" --output=/tmp/p5-build-tmp --run --force"
       }
+    },
 
-	]
+    { 
+      "name": "Run sketch fullscreen",
+      "cmd": ["processing-java", "--sketch=$file_path", "--output=$file_path/build-tmp", "--present", "--force"],
+      
+      "windows": {
+        "shell_cmd": "processing-java --sketch=\"$file_path\" --output=%TEMP%\\p5-build-tmp --present --force"
+      },
+
+      "osx": {
+        "shell_cmd": "processing-java --sketch=\"$file_path\" --output=/tmp/p5-build-tmp --present --force"
+      },
+
+      "linux": {
+        "shell_cmd": "processing-java --sketch=\"$file_path\" --output=/tmp/p5-build-tmp --present --force"
+      },
+    },
+
+    // Exporting to other platforms is unavailable from processing-java command line
+    // Bug filed https://github.com/processing/processing/issues/2760
+    { 
+      "name": "Export sketch as an application",
+      "cmd": ["processing-java", "--sketch=$file_path", "--output=$file_path/application", "--export", "--force"],
+    }
+  ]
 }


### PR DESCRIPTION
Default Build creates build-tmp folder in sketch path.
Re-run & Run fullscreen create p5-build-tmp folder in system temp
folder.