### PR TITLE
New OSX path option

### DIFF
--- a/Build Systems/Processing.sublime-build
+++ b/Build Systems/Processing.sublime-build
@@ -4,7 +4,7 @@
 	"cmd": ["processing-java", "--force", "--sketch=$file_path", "--output=$file_path/build-tmp", "--run"],
 	"file_regex": "^(...*?):([0-9]*)",
 	"encoding": "ISO8859-1",
-	"osx": { "path": "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin" },
+	"osx": { "path": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" },
 
 	"variants": [
 		{	// Close old sketch on build.

--- a/Build Systems/Processing.sublime-build
+++ b/Build Systems/Processing.sublime-build
@@ -1,13 +1,13 @@
+// If you chose to install processing-java in your home dir then change cmd to "~/processing-java" instead of "processing-java"
 {
 	"selector": "source.pde",
 	"cmd": ["processing-java", "--force", "--sketch=$file_path", "--output=$file_path/build-tmp", "--run"],
 	"file_regex": "^(...*?):([0-9]*)",
 	"encoding": "ISO8859-1",
+	"osx": { "path": "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin" },
 
-	// if you choose to install processing-java just in your home dir then use for the cmd "~/processing-java" instead of "processing-java"
 	"variants": [
-		{ 
-			// Close old sketch on build.
+		{	// Close old sketch on build.
 			"name": "Re-run sketch" ,
 			"windows": {
 				"shell_cmd": "wmic process where \"Caption Like '%java.exe%' AND CommandLine Like '%$file_base_name%'\" call terminate 1>nul && processing-java --force --sketch=\"$file_path\" --output=\"$file_path/build-tmp\" --run"
@@ -22,15 +22,18 @@
 			}
 		},
 
-		{ "cmd": ["processing-java", "--force", "--sketch=$file_path", "--run"],
+		{
+		  "cmd": ["processing-java", "--force", "--sketch=$file_path", "--run"],
 			"name": "Run sketch (Processing 3 only)"
 		},
-				
-		{ "cmd": ["processing-java", "--force", "--sketch=$file_path", "--output=$file_path/build-tmp", "--present"],
+
+		{
+		  "cmd": ["processing-java", "--force", "--sketch=$file_path", "--output=$file_path/build-tmp", "--present"],
 			"name": "Run sketch fullscreen"
 		},
 
-		{ "cmd": ["processing-java", "--force", "--sketch=$file_path", "--output=$file_path/application", "--export"],
+		{
+		  "cmd": ["processing-java", "--force", "--sketch=$file_path", "--output=$file_path/application", "--export"],
 			"name": "Export sketch as application"
 		}
 	]


### PR DESCRIPTION
Fixes #86, #81, #80.

Processing 3 installs `processing-java` in _/usr/local/bin_ instead of _/usr/bin_. On OSX, this is a problem, because Sublime Text does not use the user's `PATH`. This can easily be addressed by installing the "Fix Mac Path" package, which all OSX users should probably install anyway, but it would be better to make the "out of box" experience for this package work without installing another package.

This PR adds `osx` [platform-specific options](http://sublimetext.info/docs/en/reference/build_systems.html) for `path`. What's nice is that we declare it at the top level of the build system and all variants inherit it (no need to duplicate the option for all variants.)

@b-g This PR is to be merged to the _develop_ branch as a demonstration to others for the PR process. You can merge it to _develop_, test it to make sure I'm not crazy, and then merge it to _master_.

PS. If I am being too serious with "process" just tell me to lighten up. :beer: