### PR TITLE
New OSX path option (revised)

### DIFF
--- a/Build Systems/Processing.sublime-build
+++ b/Build Systems/Processing.sublime-build
@@ -4,7 +4,7 @@
 	"cmd": ["processing-java", "--force", "--sketch=$file_path", "--output=$file_path/build-tmp", "--run"],
 	"file_regex": "^(...*?):([0-9]*)",
 	"encoding": "ISO8859-1",
-	"osx": { "path": "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin" },
+	"osx": { "path": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" },
 
 	"variants": [
 		{	// Close old sketch on build.

--- a/Build Systems/Processing.sublime-build
+++ b/Build Systems/Processing.sublime-build
@@ -1,13 +1,13 @@
+// If you chose to install processing-java in your home dir then change cmd to "~/processing-java" instead of "processing-java"
 {
 	"selector": "source.pde",
 	"cmd": ["processing-java", "--force", "--sketch=$file_path", "--output=$file_path/build-tmp", "--run"],
 	"file_regex": "^(...*?):([0-9]*)",
 	"encoding": "ISO8859-1",
+	"osx": { "path": "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin" },
 
-	// if you choose to install processing-java just in your home dir then use for the cmd "~/processing-java" instead of "processing-java"
 	"variants": [
-		{ 
-			// Close old sketch on build.
+		{	// Close old sketch on build.
 			"name": "Re-run sketch" ,
 			"windows": {
 				"shell_cmd": "wmic process where \"Caption Like '%java.exe%' AND CommandLine Like '%$file_base_name%'\" call terminate 1>nul && processing-java --force --sketch=\"$file_path\" --output=\"$file_path/build-tmp\" --run"
@@ -22,15 +22,18 @@
 			}
 		},
 
-		{ "cmd": ["processing-java", "--force", "--sketch=$file_path", "--run"],
+		{
+		  "cmd": ["processing-java", "--force", "--sketch=$file_path", "--run"],
 			"name": "Run sketch (Processing 3 only)"
 		},
-				
-		{ "cmd": ["processing-java", "--force", "--sketch=$file_path", "--output=$file_path/build-tmp", "--present"],
+
+		{
+		  "cmd": ["processing-java", "--force", "--sketch=$file_path", "--output=$file_path/build-tmp", "--present"],
 			"name": "Run sketch fullscreen"
 		},
 
-		{ "cmd": ["processing-java", "--force", "--sketch=$file_path", "--output=$file_path/application", "--export"],
+		{
+		  "cmd": ["processing-java", "--force", "--sketch=$file_path", "--output=$file_path/application", "--export"],
 			"name": "Export sketch as application"
 		}
 	]


### PR DESCRIPTION
Note: This revised PR addresses the issue discussed in https://github.com/b-g/processing-sublime/pull/88.

This revision reorders the directories in the `path` option, to help insulate Processing 3 beta users from a problem that occurs if the old _/usr/bin/processing-java_ still exists. Note that Processing 3b6 [fixed this issue](https://github.com/processing/processing/issues/3786) by deleting the old _/usr/bin/processing-java_, so this will never be an issue for new users anyway; but this helps our package users who may be using earlier betas, and who install new versions of Processing 3, without re-installing _processing-java_.

Fixes #86, #81, #80.

Processing 3 installs _processing-java_ in _/usr/local/bin_ instead of _/usr/bin_. On OSX, this is a problem, because Sublime Text does not use the user's `PATH`. This can easily be addressed by installing the "Fix Mac Path" package, which all OSX users should probably install anyway, but it would be better to make the "out of box" experience for this package work without installing another package.

This PR adds `osx` platform-specific options for `path`. What's nice is that we declare it at the top level of the build system and all variants inherit it (no need to duplicate the option for all variants).