### PR TITLE
Look for processing-java in home directory on mac

### DIFF
--- a/Build Systems/Processing.sublime-build
+++ b/Build Systems/Processing.sublime-build
@@ -4,7 +4,7 @@
 	"cmd": ["processing-java", "--force", "--sketch=$file_path", "--output=$file_path/build-tmp", "--run"],
 	"file_regex": "^(...*?):([0-9]*)",
 	"encoding": "ISO8859-1",
-	"osx": { "path": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" },
+	"osx": { "path": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$HOME" },
 
 	"variants": [
 		{	// Close old sketch on build.


### PR DESCRIPTION
Fixes an issue with Mac OS X El Capitan where processing-java can't be installed for "all users" and as such installing it for only the current user installs it in the user's home directory.