### PR TITLE
Fix killing the current running app in multifile sketches

### DIFF
--- a/Build Systems/Processing.sublime-build
+++ b/Build Systems/Processing.sublime-build
@@ -14,7 +14,7 @@
 			},
 
 			"osx": {
-				"shell_cmd": "pkill -f $file_base_name; processing-java  --force --sketch=\"$file_path\" --output=\"$file_path/build-tmp\" --run"
+				"shell_cmd": "pkill -f \\$(basename \"$file_path\"); processing-java  --force --sketch=\"$file_path\" --output=\"$file_path/build-tmp\" --run"
 			},
 
 			"linux": {


### PR DESCRIPTION
Properly uses the sketch's executable name when you build from a multifile sketch. (Uses the folder's name instead of the file's name)