### PR TITLE
Fix #hexcode syntax highlighting inconsistencies

### DIFF
--- a/Syntaxes/Processing.tmLanguage
+++ b/Syntaxes/Processing.tmLanguage
@@ -199,7 +199,7 @@
 							<array>
 								<dict>
 									<key>include</key>
-									<string>#code</string>
+									<string>#inner-code</string>
 								</dict>
 							</array>
 						</dict>
@@ -246,7 +246,7 @@
 							<array>
 								<dict>
 									<key>include</key>
-									<string>#code</string>
+									<string>#inner-code</string>
 								</dict>
 							</array>
 						</dict>
@@ -659,6 +659,60 @@
 				</dict>
 				<dict>
 					<key>include</key>
+					<string>#operators</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#storage-modifiers</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#strings</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#all-types</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#function-calls</string>
+				</dict>
+			</array>
+		</dict>
+		<key>inner-code</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#comments</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#assertions</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#parens</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#constants-and-special-vars</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#anonymous-classes-and-new</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#keywords</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#inner-operators</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#storage-modifiers</string>
 				</dict>
 				<dict>
@@ -761,6 +815,12 @@
 				<dict>
 					<key>match</key>
 					<string>\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)([LlFfUuDd]|UL|ul)?\b</string>
+					<key>name</key>
+					<string>constant.numeric.processing</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(#[0-9a-fA-F]+)\b</string>
 					<key>name</key>
 					<string>constant.numeric.processing</string>
 				</dict>
@@ -872,17 +932,70 @@
 					<key>name</key>
 					<string>keyword.operator.processing</string>
 				</dict>
+			</array>
+		</dict>
+		<key>operators</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#common-operators</string>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>=</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.assignment.processing</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>;</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#inner-code</string>
+						</dict>
+					</array>
+				</dict>
 				<dict>
 					<key>match</key>
-					<string>(==|!=|&lt;=|&gt;=|&lt;&gt;|&lt;|&gt;)</string>
+					<string>;</string>
 					<key>name</key>
-					<string>keyword.operator.comparison.processing</string>
+					<string>punctuation.terminator.processing</string>
+				</dict>
+			</array>
+		</dict>
+		<key>inner-operators</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#common-operators</string>
 				</dict>
 				<dict>
 					<key>match</key>
 					<string>(=)</string>
 					<key>name</key>
 					<string>keyword.operator.assignment.processing</string>
+				</dict>
+			</array>
+		</dict>
+		<key>common-operators</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>(==|!=|&lt;=|&gt;=|&lt;&gt;|&lt;|&gt;)</string>
+					<key>name</key>
+					<string>keyword.operator.comparison.processing</string>
 				</dict>
 				<dict>
 					<key>match</key>
@@ -907,12 +1020,6 @@
 					<string>(?&lt;=\S)\.(?=\S)</string>
 					<key>name</key>
 					<string>keyword.operator.dereference.processing</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>;</string>
-					<key>name</key>
-					<string>punctuation.terminator.processing</string>
 				</dict>
 			</array>
 		</dict>
@@ -1060,7 +1167,7 @@
 							<array>
 								<dict>
 									<key>include</key>
-									<string>#code</string>
+									<string>#inner-code</string>
 								</dict>
 							</array>
 						</dict>
@@ -1167,7 +1274,7 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#code</string>
+					<string>#inner-code</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
Addresses #92 

There were 2 issues:
- There was never a built-in `#FFFFFF` hexcode matcher, so I added that similar to `0xFFFFFF`. This also enabled a match to `#1FFFFF`. Previously, `FFFFFF` matched because it recognized it as a constant, explaining why `1FFFFF` didn't.
- In the top level of the file (`#class-body`), `color(XXXXXX)` was recognized as a method declaration. I fixed that by breaking `#code` into `#code` and `#inner-code`. `#inner-code` doesn't include method declarations. After an assignment match ( `=`), it matches the rest of the line on `#inner-code`, thus enabling `= color(#XXXXXX)` to match properly as a function call.

Before:
![screen shot 2015-11-13 at 2 24 59 pm](https://cloud.githubusercontent.com/assets/192120/11159190/7749f16a-8a12-11e5-9fd8-1cf1e5d9c1f5.png)

After:
![screen shot 2015-11-13 at 2 25 18 pm](https://cloud.githubusercontent.com/assets/192120/11159195/7a599054-8a12-11e5-85ea-fa6666cb4e02.png)

@ybakos I'm curious to see if this fixes your sample code.
@b-g this one might need a bit of testing to make sure it didn't break anything else.