### PR TITLE
Add a command for killing all running sketches

### DIFF
--- a/Build Systems/Processing.sublime-build
+++ b/Build Systems/Processing.sublime-build
@@ -35,6 +35,21 @@
 		{
 		  "cmd": ["processing-java", "--force", "--sketch=$file_path", "--output=$file_path/application", "--export"],
 			"name": "Export sketch as application"
+		},
+
+		{
+			"name": "Kill running sketches" ,
+			"windows": {
+				"shell_cmd": "wmic process where \"Caption Like '%java.exe%' AND CommandLine Like '%$file_base_name%'\" call terminate 1>nul"
+			},
+
+			"osx": {
+				"cmd": "pkill -f ${project_base_name:\\$(basename \"$file_path\")}", "shell": true
+			},
+
+			"linux": {
+				"shell_cmd": "pkill -f \"java.*$file_path\\$\""
+			}
 		}
 	]
 }

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,0 +1,3 @@
+[
+    { "keys": ["super+."], "command": "build", "args": {"variant": "Kill running sketches"} }
+]


### PR DESCRIPTION
Also binds it to the keyboard shortcut cmd+. to mimic Xcode. (I like to think of it as "command stop" since a period is also called a full stop)

I've only tested this on Mac, but the command is the same for the re-run sketch command minus the run sketch part.